### PR TITLE
Removing the  space before POST in components stub because it raises an error in Laravel 9.

### DIFF
--- a/src/stubs/blade/create_blade.stub
+++ b/src/stubs/blade/create_blade.stub
@@ -9,7 +9,7 @@
         <div class="card">
             <div class="card-body">
 
-                <x-form.wrapper action="{{route('{{folderName}}{{modelNamePluralKebabCase}}.store')}}" method= "POST" enctype="multipart/form-data">
+                <x-form.wrapper action="{{route('{{folderName}}{{modelNamePluralKebabCase}}.store')}}" method="POST" enctype="multipart/form-data">
                         {{fieldsForCreate}}
                         <x-form.button class="btn btn-sm btn-dark" type="submit"><i class='bx bx-save bx-xs'></i> Save</x-form.button>
                 </x-form.wrapper>

--- a/src/stubs/blade/edit_blade.stub
+++ b/src/stubs/blade/edit_blade.stub
@@ -9,7 +9,7 @@
         <div class="card">
             <div class="card-body">
 
-                <x-form.wrapper action="{{route('{{folderName}}{{modelNamePluralKebabCase}}.update', ${{modelNameSingularLowerCase}}->id)}}" method= "POST" enctype="multipart/form-data">
+Amet commodi rem ip"POST" enctype="multipart/form-data">
                         @method('PATCH')
                         {{fieldsForEdit}}
                         <x-form.button class="btn btn-sm btn-dark" type="submit"><i class='bx bx-save bx-xs'></i> Save</x-form.button>

--- a/src/stubs/blade/edit_blade.stub
+++ b/src/stubs/blade/edit_blade.stub
@@ -9,7 +9,7 @@
         <div class="card">
             <div class="card-body">
 
-Amet commodi rem ip"POST" enctype="multipart/form-data">
+                <x-form.wrapper action="{{route('{{folderName}}{{modelNamePluralKebabCase}}.update', ${{modelNameSingularLowerCase}}->id)}}" method= "POST" enctype="multipart/form-data">
                         @method('PATCH')
                         {{fieldsForEdit}}
                         <x-form.button class="btn btn-sm btn-dark" type="submit"><i class='bx bx-save bx-xs'></i> Save</x-form.button>

--- a/src/stubs/blade/edit_blade.stub
+++ b/src/stubs/blade/edit_blade.stub
@@ -9,7 +9,7 @@
         <div class="card">
             <div class="card-body">
 
-                <x-form.wrapper action="{{route('{{folderName}}{{modelNamePluralKebabCase}}.update', ${{modelNameSingularLowerCase}}->id)}}" method= "POST" enctype="multipart/form-data">
+                <x-form.wrapper action="{{route('{{folderName}}{{modelNamePluralKebabCase}}.update', ${{modelNameSingularLowerCase}}->id)}}" method="POST" enctype="multipart/form-data">
                         @method('PATCH')
                         {{fieldsForEdit}}
                         <x-form.button class="btn btn-sm btn-dark" type="submit"><i class='bx bx-save bx-xs'></i> Save</x-form.button>


### PR DESCRIPTION
the  space before POST in components stub raise an error   
`syntax error, unexpected token "endif", expecting end of file`